### PR TITLE
Submenu index check

### DIFF
--- a/src/app/Page.php
+++ b/src/app/Page.php
@@ -599,7 +599,9 @@ class Page {
 		if ( isset( $all_menus ) ) {
 			foreach ( $all_menus as $key => $par_menu ) {
 				foreach ( $par_menu as $key => $submenu ) {
-					$exact_pages[] = $submenu[2];
+					if (isset($submenu[2]) {
+						$exact_pages[] = $submenu[2];
+					}
 				}
 			}
 		}

--- a/src/app/Page.php
+++ b/src/app/Page.php
@@ -599,7 +599,7 @@ class Page {
 		if ( isset( $all_menus ) ) {
 			foreach ( $all_menus as $key => $par_menu ) {
 				foreach ( $par_menu as $key => $submenu ) {
-					if (isset($submenu[2]) {
+					if (isset($submenu[2])) {
 						$exact_pages[] = $submenu[2];
 					}
 				}


### PR DESCRIPTION
There are some cases that menus don't have index 2 so a warning is trigger by php. It would be ideal to check if index is present before adding it.